### PR TITLE
Remove data classes from endpoint calls

### DIFF
--- a/examples/audit/audit_log_n_search.py
+++ b/examples/audit/audit_log_n_search.py
@@ -26,21 +26,22 @@ audit = Audit(
 
 def main():
     print("Log Data...")
-    event = Event(
-        message="Hello world",
-        actor="Someone",
-        action="Testing",
-        source="monitor",
-        status="Good",
-        target="Another spot",
-        new="New updated message",
-        old="Old message that it's been updated",
-    )
-
-    print(f"Logging: {event.dict(exclude_none=True)}")
+    msg = "Hello world"
 
     try:
-        log_response = audit.log(event=event, verify=True, verbose=False, signing=True)
+        log_response = audit.log(
+            message=msg,
+            actor="Someone",
+            action="Testing",
+            source="monitor",
+            status="Good",
+            target="Another spot",
+            new="New updated message",
+            old="Old message that it's been updated",
+            verify=True,
+            verbose=False,
+            signing=True,
+        )
         print(f"Log Request ID: {log_response.request_id}, Status: {log_response.status}")
     except pe.PangeaAPIException as e:
         print(f"Request Error: {e.response.summary}")
@@ -51,13 +52,13 @@ def main():
     print("Search Data...")
 
     page_size = 10
-
-    query = "message:" + event.message
-    restriction = SearchRestriction(source=["monitor"])
+    query = "message:" + msg
+    restriction = {"source": ["monitor"]}
 
     try:
-        search_input = SearchInput(query=query, search_restriction=restriction, limit=page_size)
-        search_res = audit.search(input=search_input, verify_consistency=True, verify_events=True)
+        search_res = audit.search(
+            query=query, search_restriction=restriction, limit=page_size, verify_consistency=True, verify_events=True
+        )
 
         result_id = search_res.result.id
         count = search_res.result.count
@@ -69,8 +70,7 @@ def main():
             offset += page_size
 
             if offset < count:
-                res_input = SearchResultInput(id=result_id, limit=page_size, offset=offset)
-                search_res = audit.results(input=res_input, verify_signatures=True)
+                search_res = audit.results(id=result_id, limit=page_size, offset=offset)
 
     except pe.PangeaAPIException as e:
         print("Search Failed:", e.response.summary)

--- a/examples/audit/log/audit.py
+++ b/examples/audit/log/audit.py
@@ -15,14 +15,11 @@ audit = Audit(token, config=config)
 
 
 def main():
-    event = Event(
-        message="Hello world",
-    )
-
-    print(f"Logging: {event.dict(exclude_none=True)}")
+    msg = "Hello world"
+    print(f"Logging: {msg}")
 
     try:
-        log_response = audit.log(event=event, verbose=False)
+        log_response = audit.log(message=msg, verbose=False)
         print(f"Response. Hash: {log_response.result.hash}")
     except pe.PangeaAPIException as e:
         print(f"Request Error: {e.response.summary}")

--- a/pangea/services/audit/models.py
+++ b/pangea/services/audit/models.py
@@ -200,7 +200,6 @@ class SearchInput(BaseModelConfig):
     query -- Natural search string; list of keywords with optional `<option>:<value>` qualifiers.
     order -- Specify the sort order of the response. "asc" or "desc".
     order_by -- Name of column to sort the results by. "message", "actor", "status", etc.
-    last -- If set, the last value from the response to fetch the next page from.
     start -- The start of the time range to perform the search on.
     end -- The end of the time range to perform the search on. All records up to the latest if left out.
     limit -- Number of audit records to include from the first page of the results.
@@ -222,7 +221,7 @@ class SearchInput(BaseModelConfig):
     include_membership_proof: Optional[bool] = None
     include_hash: Optional[bool] = None
     include_root: Optional[bool] = None
-    search_restriction: Optional[SearchRestriction] = None
+    search_restriction: Optional[dict] = None
 
 
 class RootInput(BaseModelConfig):


### PR DESCRIPTION
- use keywords arguments instead of dataclasses in endpoints call
- remove deprecated parameters
- update docs, examples and tests according to this changes